### PR TITLE
Read URL Query Params MVP

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@bos-web-engine/common": "workspace:*",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/apps/sandbox/src/hooks/useQueryParams.ts
+++ b/apps/sandbox/src/hooks/useQueryParams.ts
@@ -1,0 +1,27 @@
+import { QueryParams } from '@bos-web-engine/common';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export function useQueryParams() {
+  const searchParams = useSearchParams();
+  const [queryParams, setQueryParams] = useState<QueryParams>({});
+
+  useEffect(() => {
+    /*
+      This pattern gives us a more stable reference for queryParams to reduce
+      re-renders. We only update our state when searchParams changes.
+    */
+
+    const params: QueryParams = {};
+
+    searchParams.forEach((value, key) => {
+      params[key] = value;
+    });
+
+    setQueryParams(params);
+  }, [searchParams]);
+
+  return {
+    queryParams,
+  };
+}

--- a/apps/sandbox/src/pages/index.tsx
+++ b/apps/sandbox/src/pages/index.tsx
@@ -1,11 +1,17 @@
 import { Sandbox } from '@bos-web-engine/sandbox';
 
+import { useQueryParams } from '@/hooks/useQueryParams';
 import s from '@/styles/home.module.css';
 
 export default function Home() {
+  const { queryParams } = useQueryParams();
+
   return (
     <div className={s.wrapper}>
-      <Sandbox height="calc(100vh - var(--gateway-header-height))" />
+      <Sandbox
+        height="calc(100vh - var(--gateway-header-height))"
+        queryParams={queryParams}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/WebEngineVariants.tsx
+++ b/apps/web/src/components/WebEngineVariants.tsx
@@ -9,6 +9,7 @@ import { useHotReload } from '@bos-web-engine/hot-reload-client';
 import { AccountState } from '@near-wallet-selector/core';
 import { useCallback, useEffect, useState } from 'react';
 
+import { useQueryParams } from '@/hooks/useQueryParams';
 import { useComponentSourcesStore } from '@/stores/component-sources';
 import { useContainerMessagesStore } from '@/stores/container-messages';
 import { LocalFetchStatus, useDevToolsStore } from '@/stores/dev-tools';
@@ -25,6 +26,7 @@ export function WebEngine({
   rootComponentPath,
   flags,
 }: WebEnginePropsVariantProps) {
+  const { queryParams } = useQueryParams();
   const addSource = useComponentSourcesStore((store) => store.addSource);
   const addMessage = useContainerMessagesStore((store) => store.addMessage);
 
@@ -41,6 +43,7 @@ export function WebEngine({
       },
     },
     rootComponentPath,
+    queryParams,
   });
 
   return (
@@ -131,6 +134,7 @@ function PreparedLocalSandbox({
   flags,
   localComponents,
 }: WebEnginePropsVariantProps & { localComponents: any }) {
+  const { queryParams } = useQueryParams();
   const addSource = useComponentSourcesStore((store) => store.addSource);
   const addMessage = useContainerMessagesStore((store) => store.addMessage);
 
@@ -148,6 +152,7 @@ function PreparedLocalSandbox({
     },
     localComponents,
     rootComponentPath,
+    queryParams,
   });
 
   return (

--- a/apps/web/src/hooks/useQueryParams.ts
+++ b/apps/web/src/hooks/useQueryParams.ts
@@ -1,0 +1,27 @@
+import { QueryParams } from '@bos-web-engine/common';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export function useQueryParams() {
+  const searchParams = useSearchParams();
+  const [queryParams, setQueryParams] = useState<QueryParams>({});
+
+  useEffect(() => {
+    /*
+      This pattern gives us a more stable reference for queryParams to reduce
+      re-renders. We only update our state when searchParams changes.
+    */
+
+    const params: QueryParams = {};
+
+    searchParams.forEach((value, key) => {
+      params[key] = value;
+    });
+
+    setQueryParams(params);
+  }, [searchParams]);
+
+  return {
+    queryParams,
+  };
+}

--- a/packages/application/src/components/ComponentTree.tsx
+++ b/packages/application/src/components/ComponentTree.tsx
@@ -29,7 +29,14 @@ export default function ComponentTree({
           .map(
             ([
               componentId,
-              { trust, props, componentSource, parentId, moduleImports },
+              {
+                trust,
+                props,
+                componentSource,
+                parentId,
+                moduleImports,
+                queryParams,
+              },
             ]) => (
               /*
                 NOTE: Including currentUserAccountId as part of the key forces the entire tree 
@@ -48,7 +55,7 @@ export default function ComponentTree({
                   id={getIframeId(componentId)}
                   trust={trust}
                   scriptSrc={componentSource}
-                  componentProps={props}
+                  componentProps={{ ...queryParams, ...props }}
                   parentContainerId={parentId}
                   moduleImports={moduleImports}
                 />

--- a/packages/application/src/hooks/useWebEngine.ts
+++ b/packages/application/src/hooks/useWebEngine.ts
@@ -7,6 +7,7 @@ import type { UseWebEngineParams } from '../types';
 export function useWebEngine({
   config,
   rootComponentPath,
+  queryParams,
 }: UseWebEngineParams) {
   const { appendStylesheet } = useCss();
   const compiler = useCompiler({ config });
@@ -16,6 +17,7 @@ export function useWebEngine({
       compiler,
       config,
       rootComponentPath,
+      queryParams,
     });
 
   useComponentTree({

--- a/packages/application/src/hooks/useWebEngineSandbox.ts
+++ b/packages/application/src/hooks/useWebEngineSandbox.ts
@@ -10,6 +10,7 @@ export function useWebEngineSandbox({
   localComponents,
   config,
   rootComponentPath,
+  queryParams,
 }: UseWebEngineSandboxParams) {
   const [nonce, setNonce] = useState('');
 
@@ -27,6 +28,7 @@ export function useWebEngineSandbox({
     compiler,
     config,
     rootComponentPath,
+    queryParams,
   });
 
   const { domRoots } = useComponentTree({

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -5,6 +5,7 @@ import type {
   ComponentChildMetadata,
   ComponentTrust,
   MessagePayload,
+  QueryParams,
   SerializedArgs,
   SerializedNode,
 } from '@bos-web-engine/common';
@@ -119,6 +120,7 @@ export interface CompilerWorker extends Omit<Worker, 'postMessage'> {
 export interface UseWebEngineParams {
   config?: WebEngineConfiguration;
   rootComponentPath?: string;
+  queryParams?: QueryParams;
 }
 
 export interface UseComponentsParams extends UseWebEngineParams {

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './plugins';
 export * from './render';
 export * from './serialization';
 export * from './trust';
+export * from './url';

--- a/packages/common/src/types/url.ts
+++ b/packages/common/src/types/url.ts
@@ -1,0 +1,1 @@
+export type QueryParams = Record<string, string | undefined>;

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -265,7 +265,7 @@ export class ComponentCompiler {
    * Build the source for a container rooted at the target Component
    * @param componentId ID for the new container's root Component
    */
-  async compileComponent({ componentId }: CompilerExecuteAction) {
+  async compileComponent({ componentId, queryParams }: CompilerExecuteAction) {
     // wait on CSS initialization
     await this.cssParser.init();
 
@@ -299,6 +299,7 @@ export class ComponentCompiler {
           rawSource: moduleEntry.component,
           componentPath,
           importedModules: retrievedData.importedModules,
+          queryParams,
         });
 
         return;
@@ -354,6 +355,7 @@ export class ComponentCompiler {
       rawSource: moduleEntry.component,
       componentPath,
       importedModules,
+      queryParams,
     });
   }
 }

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -1,4 +1,4 @@
-import type { BOSModule } from '@bos-web-engine/common';
+import type { BOSModule, QueryParams } from '@bos-web-engine/common';
 import type {
   BLOCK_HEIGHT_KEY,
   SOCIAL_COMPONENT_NAMESPACE,
@@ -12,6 +12,7 @@ export type ComponentCompilerRequest =
 export interface CompilerExecuteAction {
   action: 'execute';
   componentId: string;
+  queryParams?: QueryParams;
 }
 
 export type LocalComponentMap = { [path: string]: BOSModule };
@@ -35,6 +36,7 @@ export interface ComponentCompilerResponse {
   componentPath: string;
   error?: Error;
   importedModules: Map<string, string>;
+  queryParams?: QueryParams;
 }
 
 export type SendMessageCallback = (res: ComponentCompilerResponse) => void;

--- a/packages/sandbox/src/components/Preview.tsx
+++ b/packages/sandbox/src/components/Preview.tsx
@@ -21,6 +21,7 @@ type WebEngineLocalComponents = { [path: string]: BOSModule };
 
 export function Preview() {
   const { account } = useWallet();
+  const queryParams = useSandboxStore((store) => store.queryParams);
   const containerElement = useSandboxStore((store) => store.containerElement);
   const activeFilePath = useSandboxStore((store) => store.activeFilePath);
   const pinnedPreviewFilePath = useSandboxStore(
@@ -43,6 +44,7 @@ export function Preview() {
   const { components, nonce } = useWebEngineSandbox({
     localComponents,
     rootComponentPath,
+    queryParams,
   });
 
   useEffect(() => {

--- a/packages/sandbox/src/components/Sandbox.tsx
+++ b/packages/sandbox/src/components/Sandbox.tsx
@@ -1,3 +1,4 @@
+import { QueryParams } from '@bos-web-engine/common';
 import { useEffect, useRef, useState } from 'react';
 
 import { Layout } from './Layout';
@@ -8,13 +9,15 @@ import { useSourceAccountReplace } from '../hooks/useSourceAccountReplace';
 
 type Props = {
   height: string;
+  queryParams?: QueryParams;
 };
 
-export function Sandbox({ height }: Props) {
+export function Sandbox({ height, queryParams }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const setContainerElement = useSandboxStore(
     (store) => store.setContainerElement
   );
+  const setQueryParams = useSandboxStore((store) => store.setQueryParams);
   const [shouldRender, setShouldRender] = useState(false);
 
   usePublishedFilesSync();
@@ -33,6 +36,10 @@ export function Sandbox({ height }: Props) {
       setContainerElement(containerRef.current);
     }
   });
+
+  useEffect(() => {
+    setQueryParams(queryParams);
+  }, [setQueryParams, queryParams]);
 
   if (!shouldRender) return null;
 

--- a/packages/sandbox/src/hooks/useSandboxStore.ts
+++ b/packages/sandbox/src/hooks/useSandboxStore.ts
@@ -1,3 +1,4 @@
+import { QueryParams } from '@bos-web-engine/common';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
@@ -28,6 +29,7 @@ type SandboxStore = {
   mode: SandboxMode;
   pinnedPreviewFilePath: string | undefined;
   publishedFiles: SandboxFiles;
+  queryParams: QueryParams | undefined;
 
   addNewFile: (
     options?: Partial<{
@@ -49,6 +51,7 @@ type SandboxStore = {
   setMode: (mode: SandboxMode) => void;
   setPinnedPreviewFile: (path: string | undefined) => void;
   setPublishedFiles: (files: SandboxFiles) => void;
+  setQueryParams: (params: QueryParams | undefined) => void;
   updateFilePath: (currentPath: string, newPath: string) => void;
 };
 
@@ -65,6 +68,7 @@ export const useSandboxStore = create<SandboxStore>()(
       mode: 'EDIT',
       pinnedPreviewFilePath: undefined,
       publishedFiles: {},
+      queryParams: undefined,
 
       addNewFile: ({ file, shouldFocusRenameInput = true } = {}) => {
         const state = get();
@@ -150,6 +154,8 @@ export const useSandboxStore = create<SandboxStore>()(
 
       setPublishedFiles: (publishedFiles) =>
         set(() => ({ isInitializingPublishedFiles: false, publishedFiles })),
+
+      setQueryParams: (queryParams) => set(() => ({ queryParams })),
 
       updateFilePath: (currentPath, newPath) =>
         set((state) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
     devDependencies:
+      '@bos-web-engine/common':
+        specifier: workspace:*
+        version: link:../../packages/common
       '@types/node':
         specifier: ^20
         version: 20.0.0


### PR DESCRIPTION
Closes: https://github.com/near/react-on-chain/issues/334

Please check out this comment for more context on the implementation in this PR: https://github.com/near/react-on-chain/issues/334#issuecomment-2070858868

The implementation itself is pretty simple and should be easy to refactor if any of us have concerns down the road. Here's an example component you can check out: https://bos-web-engine-git-feat-read-url-f462bd-near-developer-console.vercel.app/near/RocTest?foobar=abc

I made sure this implementation will support Next's `<Link>` component (client side routing) if/when we start using that inside our RoC components. The query parameters update and the root component receives the updated props.

Viewing the gateway:

![Screen Shot 2024-04-25 at 11 53 26 AM](https://github.com/near/react-on-chain/assets/1475067/03ab9f3f-11e6-4814-8e45-5a5fd358a9a8)

Viewing the sandbox:

![Screen Shot 2024-04-25 at 12 05 41 PM](https://github.com/near/react-on-chain/assets/1475067/fe6be206-6418-4f1c-a72c-9869dbbef7ea)
